### PR TITLE
Refactor ProductRegistryEvent to ProductRegistryMessage Implementation

### DIFF
--- a/apps/of-product-registry-microservices/product.registry.read/src/main/java/org/ormi/priv/tfa/orderflow/product/registry/read/service/ProductRegistryEventConsumer.java
+++ b/apps/of-product-registry-microservices/product.registry.read/src/main/java/org/ormi/priv/tfa/orderflow/product/registry/read/service/ProductRegistryEventConsumer.java
@@ -2,6 +2,8 @@ package org.ormi.priv.tfa.orderflow.product.registry.read.service;
 
 import org.eclipse.microprofile.reactive.messaging.Incoming;
 import org.ormi.priv.tfa.orderflow.lib.publishedlanguage.event.ProductRegistryEvent;
+import org.ormi.priv.tfa.orderflow.lib.publishedlanguage.message.ProductRegistryMessage;
+import org.ormi.priv.tfa.orderflow.lib.publishedlanguage.error.ProductRegistryError;
 import org.ormi.priv.tfa.orderflow.product.registry.read.projection.ProductRegistryProjector;
 
 import jakarta.enterprise.context.ApplicationScoped;
@@ -16,9 +18,17 @@ public class ProductRegistryEventConsumer {
 
   @Incoming("product-registry-event")
   @Transactional(Transactional.TxType.REQUIRED)
-  public void handleEvent(ProductRegistryEvent event) {
+  public void handleEvent(ProductRegistryMessage message) {
     // Project the event
-    projector.handleEvent(event);
+    if (message instanceof ProductRegistryEvent event) {
+      projector.handleEvent(event);
+    }
+    else if (message instanceof ProductRegistryError error) {
+      throw new RuntimeException("Error while processing event: " + error.getMessage());
+    }
+    else {
+      throw new RuntimeException("Unknown message type: " + message.getClass().getName());
+    }
     // TODO: Sink the event here once or while projection is processed
   }
 }

--- a/libs/published-language/src/main/java/org/ormi/priv/tfa/orderflow/lib/publishedlanguage/error/ProductRegistryError.java
+++ b/libs/published-language/src/main/java/org/ormi/priv/tfa/orderflow/lib/publishedlanguage/error/ProductRegistryError.java
@@ -2,7 +2,7 @@ package org.ormi.priv.tfa.orderflow.lib.publishedlanguage.error;
 
 import org.ormi.priv.tfa.orderflow.lib.publishedlanguage.message.ProductRegistryMessage;
 
-class ProductRegistryError implements ProductRegistryMessage{
+public class ProductRegistryError implements ProductRegistryMessage{
     public final String message;
     public final String errorCode;
 

--- a/libs/published-language/src/main/java/org/ormi/priv/tfa/orderflow/lib/publishedlanguage/error/ProductRegistryError.java
+++ b/libs/published-language/src/main/java/org/ormi/priv/tfa/orderflow/lib/publishedlanguage/error/ProductRegistryError.java
@@ -1,0 +1,47 @@
+package org.ormi.priv.tfa.orderflow.lib.publishedlanguage.error;
+
+import org.ormi.priv.tfa.orderflow.lib.publishedlanguage.message.ProductRegistryMessage;
+
+class ProductRegistryError implements ProductRegistryMessage{
+    public final String message;
+    public final String errorCode;
+
+    public ProductRegistryError(String message, String errorCode) {
+        this.message = message;
+        this.errorCode = errorCode;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public String getErrorCode() {
+        return errorCode;
+    }
+
+    @Override
+    public String toString() {
+        return "ProductRegistryError{" +
+                "message='" + message + '\'' +
+                ", errorCode='" + errorCode + '\'' +
+                '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        ProductRegistryError that = (ProductRegistryError) o;
+
+        if (message != null ? !message.equals(that.message) : that.message != null) return false;
+        return errorCode != null ? errorCode.equals(that.errorCode) : that.errorCode == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = message != null ? message.hashCode() : 0;
+        result = 31 * result + (errorCode != null ? errorCode.hashCode() : 0);
+        return result;
+    }
+}

--- a/libs/published-language/src/main/java/org/ormi/priv/tfa/orderflow/lib/publishedlanguage/event/ProductRegistryEvent.java
+++ b/libs/published-language/src/main/java/org/ormi/priv/tfa/orderflow/lib/publishedlanguage/event/ProductRegistryEvent.java
@@ -1,5 +1,7 @@
 package org.ormi.priv.tfa.orderflow.lib.publishedlanguage.event;
 
+
+import org.ormi.priv.tfa.orderflow.lib.publishedlanguage.message.ProductRegistryMessage;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
@@ -14,7 +16,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 @JsonSubTypes({
     @JsonSubTypes.Type(value = ProductRegistered.class, name = "ProductRegistered"),
     @JsonSubTypes.Type(value = ProductUpdated.class, name = "ProductUpdated"),
-    @JsonSubTypes.Type(value = ProductRemoved.class, name = "ProductRemoved")
+    @JsonSubTypes.Type(value = ProductRemoved.class, name = "ProductRemoved"),
 })
-public sealed interface ProductRegistryEvent permits ProductRegistered, ProductRemoved, ProductUpdated {
+public sealed interface ProductRegistryEvent extends ProductRegistryMessage permits ProductRegistered, ProductRemoved, ProductUpdated  {
 }

--- a/libs/published-language/src/main/java/org/ormi/priv/tfa/orderflow/lib/publishedlanguage/message/ProductRegistryMessage.java
+++ b/libs/published-language/src/main/java/org/ormi/priv/tfa/orderflow/lib/publishedlanguage/message/ProductRegistryMessage.java
@@ -1,0 +1,5 @@
+package org.ormi.priv.tfa.orderflow.lib.publishedlanguage.message;
+
+public interface ProductRegistryMessage {
+    
+}


### PR DESCRIPTION
This pull request introduces the ProductRegistryMessage interface and its implementation, streamlining the way product registry interactions are handled. The changes replace the use of ProductRegistryEvent with the newly created ProductRegistryMessage, ensuring better alignment with the intended design and improving maintainability.

Key Changes:
- Created the ProductRegistryMessage interface and its associated implementation, ProductRegistryEvent.
- Updated references throughout the codebase to replace ProductRegistryEvent with ProductRegistryMessage.